### PR TITLE
correct the usage of tail command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Check the [slides](melgan_slides.pdf) if you aren't attending the NeurIPS 2019 c
 Create a raw folder with all the samples stored in `wavs/` subfolder.
 Run these commands:
    ```command
-   ls wavs/*.wav | tail -n+10 > train_files.txt
+   ls wavs/*.wav | tail -n+11 > train_files.txt
    ls wavs/*.wav | head -n10 > test_files.txt
    ```
 


### PR DESCRIPTION
While using the `head` command to reserve the first 10 audio files for testing, the option `-n+11` instead of `-n+10` should be specified following the `tail` command.
Otherwise the first line in *train_files.txt* would be the same as the last line in *test_files.txt*.