### PR TITLE
Removing the last unnecessary downsampling in Discriminator

### DIFF
--- a/mel2wav/modules.py
+++ b/mel2wav/modules.py
@@ -192,8 +192,9 @@ class Discriminator(nn.Module):
         self.apply(weights_init)
 
     def forward(self, x):
-        results = []
-        for key, disc in self.model.items():
-            results.append(disc(x))
+        results = [self.model["disc_0"](x)]
+        for i in range(1, self.num_D):
             x = self.downsample(x)
+            results.append(self.model[f"disc_{i}"](x))
+
         return results


### PR DESCRIPTION
Refactoring of  `forward()` method in `Discriminator`, to prevent last (unnecessary) downsampling.
```python
    def forward(self, x):
        results = []
        for key, disc in self.model.items():
            results.append(disc(x))
            x = self.downsample(x) # <-- this is unnecessary in the last iteration of the loop
        return results
``` 